### PR TITLE
feat: Add CardGrid component

### DIFF
--- a/app/features/CardGrid/CardGrid.css
+++ b/app/features/CardGrid/CardGrid.css
@@ -1,0 +1,6 @@
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: var(--space-m);
+  padding: var(--space-m);
+}

--- a/app/features/CardGrid/CardGrid.stories.tsx
+++ b/app/features/CardGrid/CardGrid.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import vulpixData from "../../mock/vulpix.json";
+import { CardGrid } from "./";
+
+const meta: Meta<typeof CardGrid> = {
+  title: "Components/CardGrid",
+  component: CardGrid,
+};
+
+export default meta;
+type Story = StoryObj<typeof CardGrid>;
+
+const vulpixCard = {
+  id: vulpixData.id,
+  name: vulpixData.name,
+  type: vulpixData.types[0].type.name,
+  artwork: vulpixData.sprites.other["official-artwork"].front_shiny,
+};
+
+export const FiveVulpixes: Story = {
+  args: {
+    cards: Array(5).fill(vulpixCard),
+  },
+};

--- a/app/features/CardGrid/CardGrid.tsx
+++ b/app/features/CardGrid/CardGrid.tsx
@@ -1,0 +1,27 @@
+import { Card } from "../Card";
+import "./CardGrid.css";
+
+interface CardGridProps {
+  cards: Array<{
+    id: number;
+    name: string;
+    type: string;
+    artwork: string;
+  }>;
+}
+
+export default function CardGrid({ cards }: CardGridProps) {
+  return (
+    <div className="card-grid">
+      {cards.map((card) => (
+        <Card
+          key={card.id}
+          id={card.id}
+          name={card.name}
+          type={card.type}
+          artwork={card.artwork}
+        />
+      ))}
+    </div>
+  );
+}

--- a/app/features/CardGrid/index.ts
+++ b/app/features/CardGrid/index.ts
@@ -1,0 +1,1 @@
+export { default as CardGrid } from "./CardGrid";


### PR DESCRIPTION
This pull request introduces a new `CardGrid` component, which includes the necessary styling, storybook stories, and component definition. The most important changes are grouped by theme as follows:

Introduction of `CardGrid` component:

* [`app/features/CardGrid/CardGrid.tsx`](diffhunk://#diff-f491834905608dc70f107976f05b2d109fa4da70ef8d1a698cd6af8567d11627R1-R27): Added the `CardGrid` component, which takes an array of card objects and renders them using the `Card` component.
* [`app/features/CardGrid/index.ts`](diffhunk://#diff-8e669c5c029361fc874392291b2331e4b55bf5172a5a60eba5cb7b87ef8d71c2R1): Exported the `CardGrid` component for use in other parts of the application.

Styling for `CardGrid` component:

* [`app/features/CardGrid/CardGrid.css`](diffhunk://#diff-594b329178ea396d3b7041bea4c09d8ca4ad22f1dc75471152678c4a0bdc6973R1-R6): Added CSS styles for the `CardGrid` component to display cards in a grid layout with appropriate spacing.

Storybook stories for `CardGrid` component:

* [`app/features/CardGrid/CardGrid.stories.tsx`](diffhunk://#diff-772303a254792e92513a02aace94ab1104c774ccb06420400406e9d632e27441R1-R24): Added storybook stories for the `CardGrid` component, including a story that displays five Vulpix cards.- Create responsive grid layout for Pokemon cards\n- Add story with 5 Vulpix examples\n- Use established spacing variables for consistent layout