### PR TITLE
Refactor/pokemon fetch

### DIFF
--- a/app/features/Card/Card.tsx
+++ b/app/features/Card/Card.tsx
@@ -7,8 +7,8 @@ import "./Card.css";
 interface CardProps {
   id: number;
   name: string;
-  type: string;
-  artwork: string;
+  type?: string;
+  artwork?: string;
 }
 
 export default function Card({ id, name, type, artwork }: CardProps) {
@@ -19,20 +19,25 @@ export default function Card({ id, name, type, artwork }: CardProps) {
   };
 
   return (
-    <button className={`card ${type}`} onClick={handleFlip}>
+    <button className={`card ${type || "unknown"}`} onClick={handleFlip}>
       <div className={`card__face ${flipped ? "flipped" : ""}`}>
         {!flipped ? (
           <>
-            <Image
-              src={artwork}
-              alt={`${name} artwork`}
-              width={250}
-              height={250}
-              priority
-            />
+            {artwork ? (
+              <Image
+                src={artwork}
+                alt={`${name} artwork`}
+                width={250}
+                height={250}
+                style={{ width: "auto", height: "auto" }}
+                priority
+              />
+            ) : (
+              <div className="placeholder">?</div>
+            )}
             <h2>{name}</h2>
             <p>#{id}</p>
-            <p>{type}</p>
+            <p>{type || "Unknown"}</p>
           </>
         ) : (
           <>

--- a/app/features/CardGrid/CardGrid.tsx
+++ b/app/features/CardGrid/CardGrid.tsx
@@ -5,8 +5,8 @@ interface CardGridProps {
   cards: Array<{
     id: number;
     name: string;
-    type: string;
-    artwork: string;
+    type?: string;
+    artwork?: string;
   }>;
 }
 

--- a/app/types/pokemon.ts
+++ b/app/types/pokemon.ts
@@ -39,6 +39,6 @@ export interface Pokemon {
 export interface PokemonCardData {
   id: number;
   name: string;
-  type: string;
-  artwork: string;
+  type: string | undefined;
+  artwork: string | undefined;
 }


### PR DESCRIPTION
This pull request includes significant changes to the `fetchGen1Pokemon` function in `app/services/pokemon.ts`, updates to the `PokemonCardData` interface in `app/types/pokemon.ts`, and a minor style adjustment in `app/features/Card/Card.tsx`. The most important changes include restructuring the `fetchGen1Pokemon` function to handle errors more gracefully and updating the `PokemonCardData` interface to allow undefined values for `type` and `artwork`.

### Improvements to Pokemon fetching logic:

* [`app/services/pokemon.ts`](diffhunk://#diff-601931751e98edd9e5b364ba10ecfc8542078136913f970935a7ff06f89c807bL5-R94): Restructured the `fetchGen1Pokemon` function to fetch a list of Pokemon first, then fetch details for each Pokemon in parallel. Added error handling to provide fallback data if fetching details fails.

### Interface updates:

* [`app/types/pokemon.ts`](diffhunk://#diff-6e4898db49caf89ff5e6efbe300017f08b0c99c9671a2c9982a9013455461719L42-R43): Updated the `PokemonCardData` interface to allow `type` and `artwork` to be `undefined`, accommodating cases where fetching details fails.

### Style adjustments:

* [`app/features/Card/Card.tsx`](diffhunk://#diff-f226a20e6daa790cc5cc3658f9e25399ef0fdf646bc562a87e5d3f70e6d65e1cR31): Added inline styles to the `Image` component to set width and height to "auto".